### PR TITLE
Prevent overflow when mapping against WB

### DIFF
--- a/ColorRecognitionTCS230/ColorRecognitionTCS230.cpp
+++ b/ColorRecognitionTCS230/ColorRecognitionTCS230.cpp
@@ -63,14 +63,23 @@ void ColorRecognitionTCS230::timerInterruptHandler() {
 }
 
 unsigned char ColorRecognitionTCS230::getRed() {
+	if (lastFrequencies[0]>whiteBalanceFrequencies[0]) { 
+		return 255; 
+	}
     return (unsigned char) map(lastFrequencies[0], 0, whiteBalanceFrequencies[0], 0, 255);
 }
 
 unsigned char ColorRecognitionTCS230::getGreen() {
+	if (lastFrequencies[1]>whiteBalanceFrequencies[1]) { 
+		return 255; 
+	}
     return (unsigned char) map(lastFrequencies[1], 0, whiteBalanceFrequencies[1], 0, 255);
 }
 
 unsigned char ColorRecognitionTCS230::getBlue() {
+	if (lastFrequencies[2]>whiteBalanceFrequencies[2]) { 
+		return 255; 
+	}
     return (unsigned char) map(lastFrequencies[2], 0, whiteBalanceFrequencies[2], 0, 255);
 }
 


### PR DESCRIPTION
If the current reading is higher than the white-balance reading, return
255 instead of overflowing. (Reduces disco crazy colors with shiny or
brighter or closer objects.)
